### PR TITLE
{SnipeIT} feat: Get assets by query

### DIFF
--- a/pkg/snipeit/assets.go
+++ b/pkg/snipeit/assets.go
@@ -47,6 +47,8 @@ type AssetQuery struct {
 	LocationID     int    `url:"location_id,omitempty"`     // Return only assets associated with the specified location ID.
 	Status         string `url:"status,omitempty"`          // Optionally restrict asset results to one of these status types: RTD, Deployed, Undeployable, Deleted, Archived, Requestable
 	StatusID       int    `url:"status_id,omitempty"`       // Return only assets associated with the specified status ID.
+	AssignedTo     int    `url:"assigned_to,omitempty"`     // Return only assets that are assigned to this ID (requires AssignedType) *Not in api reference doc but used on the web hosted service*
+	AssignedType   string `url:"assigned_type,omitempty"`   // Return only assets of this type that are assigned to a specific ID (requires AssignedTo and uses the original snipeit models) https://github.com/snipe/snipe-it/tree/master/app/Models *Not in api reference but used on the web hosted service*
 }
 
 // ### AssetQuery implements QueryInterface
@@ -66,6 +68,8 @@ func (q *AssetQuery) Copy() QueryInterface {
 		LocationID:     q.LocationID,
 		Status:         q.Status,
 		StatusID:       q.StatusID,
+		AssignedTo:     q.AssignedTo,
+		AssignedType:   q.AssignedType,
 	}
 }
 
@@ -92,7 +96,7 @@ func (q *AssetQuery) SetOffset(offset int) {
 * List all Hardware Assets that conform to a query in Snipe-IT
 * /api/v1/hardware
 * - https://snipe-it.readme.io/reference/hardware-list
-*/
+ */
 func (c *AssetClient) GetAssetsByQuery(q AssetQuery) (*HardwareList, error) {
 	url := c.BuildURL(Assets)
 

--- a/pkg/snipeit/assets.go
+++ b/pkg/snipeit/assets.go
@@ -89,17 +89,12 @@ func (q *AssetQuery) SetOffset(offset int) {
 //---------------------------------------------------------------------
 
 /*
- * List all Hardware Assets in Snipe-IT
- * /api/v1/hardware
- * - https://snipe-it.readme.io/reference/hardware-list
- */
-func (c *AssetClient) GetAllAssets() (*HardwareList, error) {
+* List all Hardware Assets that conform to a query in Snipe-IT
+* /api/v1/hardware
+* - https://snipe-it.readme.io/reference/hardware-list
+*/
+func (c *AssetClient) GetAssetsByQuery(q AssetQuery) (*HardwareList, error) {
 	url := c.BuildURL(Assets)
-
-	q := AssetQuery{
-		Limit:  500,
-		Offset: 0,
-	}
 
 	var cache HardwareList
 	if c.GetCache(url, &cache) {
@@ -113,6 +108,20 @@ func (c *AssetClient) GetAllAssets() (*HardwareList, error) {
 
 	c.SetCache(url, assets, 5*time.Minute)
 	return assets, nil
+}
+
+/*
+ * List all Hardware Assets in Snipe-IT
+ * /api/v1/hardware
+ * - https://snipe-it.readme.io/reference/hardware-list
+ */
+func (c *AssetClient) GetAllAssets() (*HardwareList, error) {
+	q := AssetQuery{
+		Limit:  500,
+		Offset: 0,
+	}
+
+	return c.GetAssetsByQuery(q)
 }
 
 /*


### PR DESCRIPTION
There are no defaults (like limit or offset) on GetAssetsByQuery() that should fall on whoever is creating the request.

---
Added 2 new query fields that are not shown on the api reference but that it are used by the web hosted service to get all the assets that are assigned to another asset.

For example if asset with ID 1 has assets 2, 3, 4 assigned to it then you would need the following query param values.

AssignedTo: 1 (ID of parent asset)
AssigendType: "App/Models/Asset" (What type of assets are assigned. This comes directly from the [models](https://github.com/snipe/snipe-it/tree/master/app/Models) on their github with the value being the path to the model, similar to how you would import that model in php)
  